### PR TITLE
Updated CRAN website link

### DIFF
--- a/slides/01-getting-started-slides.html
+++ b/slides/01-getting-started-slides.html
@@ -160,7 +160,7 @@ background-image: url("images/installation.jpeg")
 
 ## Install R
 
-The first thing you need to do is download the R software. Go to the [Comprehensive R Archive Network (aka “CRAN”) website](https://cran.cnr.berkeley.edu/) and download the software for your operating system (Windows, Mac, or Linux).
+The first thing you need to do is download the R software. Go to the [Comprehensive R Archive Network (aka “CRAN”) website](https://cran.r-project.org/) and download the software for your operating system (Windows, Mac, or Linux).
 
 ![](images/download-r.png)
 


### PR DESCRIPTION
Original link ['Red Hat Enterprise Linux Test Page'](https://cran.cnr.berkeley.edu/) (screenshot below) should point to [The Comprehensive R Archive Network](https://cran.r-project.org/).
<img width="1760" alt="Screen Shot 2020-04-30 at 10 07 58 PM" src="https://user-images.githubusercontent.com/39413445/80778802-3957ca80-8b2f-11ea-8bf5-683f1d1da4bb.png">